### PR TITLE
Remove `#[feature(let-chanins)]` to build on stable rust

### DIFF
--- a/loader/src/lib.rs
+++ b/loader/src/lib.rs
@@ -101,7 +101,6 @@
 //! }
 //! ```
 
-#![feature(let_chains)]
 #![allow(clippy::new_without_default)]
 #![allow(clippy::let_and_return)]
 #![warn(missing_docs)]


### PR DESCRIPTION
Thank you for writing web-static-pack!  I would like to use it on stable rust.

The `let-chains` feature is stable since 1.88, so the feature annotation seems to be all the keeps this crate from building and working on stable rust.